### PR TITLE
Port a change from upstream to fix a memory leak, and fix our build

### DIFF
--- a/build/org.eclipse.birt.target/org.eclipse.birt.target.target
+++ b/build/org.eclipse.birt.target/org.eclipse.birt.target.target
@@ -51,7 +51,7 @@
 			<unit id="org.eclipse.rcp.configuration.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.29"/>
 			<unit id="org.eclipse.emf.base.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.feature.group" version="0.0.0"/>
@@ -129,7 +129,7 @@
 			<unit id="org.apache.xalan.source" version="2.7.2.v20201124-1837"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.26.0/R-3.26.0-20220526191850/repository"/>
+			<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.25.0/R-3.25.0-20220224093948/repository"/>
 			<unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.jst.web_ui.feature.feature.group" version="0.0.0"/>

--- a/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/QueryResults.java
+++ b/data/org.eclipse.birt.data/src/org/eclipse/birt/data/engine/impl/QueryResults.java
@@ -1,13 +1,13 @@
 /*
  *************************************************************************
  * Copyright (c) 2004, 2014 Actuate Corporation.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * https://www.eclipse.org/legal/epl-2.0/.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *
  * Contributors:
  *  Actuate Corporation - initial API and implementation
@@ -249,7 +249,7 @@ public class QueryResults implements IQueryResults, IQueryService {
 			iterator = null;
 		}
 
-		// queryService.close( );
+		queryService.close(); /* Reintroduced to fix #875 */
 		queryService = null;
 		logger.logp(Level.FINER, QueryResults.class.getName(), "close",
 				"Iterators associated with QueryResults are closed");

--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,13 @@
 			</activation>
 			<properties>
 				<eclipse.release.name>latest</eclipse.release.name>
-				<eclipse.repo.url>http://download.eclipse.org/eclipse/updates/latest/</eclipse.repo.url>
+				<eclipse.repo.url>http://download.eclipse.org/eclipse/updates/4.9/</eclipse.repo.url>
 				<emf.repo.url>http://download.eclipse.org/modeling/emf/emf/builds/milestone/latest</emf.repo.url>
 				<gef.repo.url>http://download.eclipse.org/tools/gef/updates/legacy/releases/</gef.repo.url>
 				<!-- https://wiki.eclipse.org/WTP_FAQ#How_do_I_install_WTP.3F -->
 				<!-- wtp.repo.url>https://download.eclipse.org/webtools/downloads/drops/R3.13.0/R-3.13.0-20190308131645/repository/</wtp.repo.url -->
 				<!-- http://download.eclipse.org/tools/orbit/downloads/ -->
-				<orbit.repo.url>https://download.eclipse.org/tools/orbit/downloads/latest-R</orbit.repo.url>
+				<orbit.repo.url>https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233</orbit.repo.url>
 				<!-- https://eclipse.org/datatools/downloads.php -->
 				<dtp.repo.url>https://download.eclipse.org/datatools/updates/1.14.200-SNAPSHOT/repository/</dtp.repo.url>
 				<jetty.version>10.0.6</jetty.version>


### PR DESCRIPTION
The current 4.9.0 has an aggressive memory leak, which was fixed in 4.10.0. Unfortunately 4.10.0 has unintentionally upgraded their javascript library, which breaks older javascript in our reports. So we're porting their change to our branch. I've also changed some of the repositorys we point to, so we don't end up unintentionally upgrading as well.